### PR TITLE
Encounter-calculator page

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,7 @@
 {
   "extends": ["next/core-web-vitals", "plugin:unicorn/recommended"],
   "rules": {
-    "unicorn/no-null": 0
+    "unicorn/no-null": 0,
+    "unicorn/no-nested-ternary": 0
   }
 }

--- a/components/encounter-table.tsx
+++ b/components/encounter-table.tsx
@@ -1,0 +1,105 @@
+import { toInteger } from "lodash";
+
+interface EncounterTableP {
+  playerCount: number;
+  battleCount: number;
+  level: number;
+}
+export default function EncounterTable({
+  playerCount,
+  level,
+  battleCount: battlecount,
+}: EncounterTableP) {
+  const meqBudget = [0, 1, 2, 3, 5, 7, 9, 11][playerCount];
+  const mookFactor = [0, 3, 3, 4, 4, 5, 5, 5, 5, 5, 5][level];
+  let eliteMookFactor: number | string = mookFactor * 1.5;
+  if (eliteMookFactor !== toInteger(eliteMookFactor)) {
+    const low = Math.floor(eliteMookFactor);
+    const high = Math.ceil(eliteMookFactor);
+    eliteMookFactor = `${low}-${high}`;
+  }
+  const parLevelBase = level < 5 ? level : level < 8 ? level + 1 : level + 2;
+  const parLevel = battlecount === 4 ? parLevelBase : parLevelBase + 1;
+
+  return (
+    <>
+      <p>
+        Budget for a standard battle: <strong>{meqBudget} MEQ</strong>
+      </p>
+
+      <div className="overflow-auto border dark:border-stone-700 rounded shadow bg-white dark:bg-stone-700 border-stone-300 my-2">
+        <table>
+          <thead>
+            <tr>
+              <th>Monster level</th>
+              <th>Standard / {mookFactor} mooks</th>
+              <th>Elite / {eliteMookFactor} mooks</th>
+              <th>2x / large / {mookFactor * 2} mooks</th>
+              <th>3x / huge / {mookFactor * 3} mooks</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>{parLevel - 2}</td>
+              <td>0.5</td>
+              <td>0.7</td>
+              <td>1</td>
+              <td>1.5</td>
+            </tr>
+            <tr>
+              <td>{parLevel - 1}</td>
+              <td>0.7</td>
+              <td>1</td>
+              <td>1.5</td>
+              <td>2</td>
+            </tr>
+            <tr>
+              <td>
+                <strong>{parLevel}</strong>
+              </td>
+              <td>
+                <strong>1</strong>
+              </td>
+              <td>
+                <strong>1.5</strong>
+              </td>
+              <td>
+                <strong>2</strong>
+              </td>
+              <td>
+                <strong>3</strong>
+              </td>
+            </tr>
+            <tr>
+              <td>{parLevel + 1}</td>
+              <td>1.5</td>
+              <td>2*</td>
+              <td>3*</td>
+              <td>4*</td>
+            </tr>
+            <tr>
+              <td>{parLevel + 2}</td>
+              <td>2*</td>
+              <td>3**</td>
+              <td>4**</td>
+              <td>6**</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <p>
+        <em>
+          * Be careful. A monster like this might pack an uncomfortable amount
+          of damage into a single swing.
+        </em>
+      </p>
+      <p>
+        <em>
+          ** Probably a mistake to build a battle around monsters that dish out
+          damage like these do.
+        </em>
+      </p>
+    </>
+  );
+}

--- a/components/encounter-table.tsx
+++ b/components/encounter-table.tsx
@@ -1,4 +1,7 @@
+import { getI18nProperties } from "@/lib/get-static";
 import { toInteger } from "lodash";
+import { GetStaticPropsContext, GetStaticPropsResult } from "next";
+import { useTranslation } from "next-i18next";
 
 interface EncounterTableP {
   playerCount: number;
@@ -21,21 +24,23 @@ export default function EncounterTable({
   const parLevelBase = level < 5 ? level : level < 8 ? level + 1 : level + 2;
   const parLevel = battlecount === 4 ? parLevelBase : parLevelBase + 1;
 
+  const { t } = useTranslation("calculator");
+
   return (
     <>
       <p>
-        Budget for a standard battle: <strong>{meqBudget} MEQ</strong>
+        {t("budget")} <strong>{t("budgetresult", { meq: meqBudget })}</strong>
       </p>
 
       <div className="overflow-auto border dark:border-stone-700 rounded shadow bg-white dark:bg-stone-700 border-stone-300 my-2">
         <table>
           <thead>
             <tr>
-              <th>Monster level</th>
-              <th>Standard / {mookFactor} mooks</th>
-              <th>Elite / {eliteMookFactor} mooks</th>
-              <th>2x / large / {mookFactor * 2} mooks</th>
-              <th>3x / huge / {mookFactor * 3} mooks</th>
+              <th>{t("monsterlevel")}</th>
+              <th>{t("standard", { mooks: mookFactor })}</th>
+              <th>{t("elite", { mooks: eliteMookFactor })}</th>
+              <th>{t("large", { mooks: mookFactor * 2 })}</th>
+              <th>{t("huge", { mooks: mookFactor * 3 })}</th>
             </tr>
           </thead>
           <tbody>
@@ -89,16 +94,10 @@ export default function EncounterTable({
       </div>
 
       <p>
-        <em>
-          * Be careful. A monster like this might pack an uncomfortable amount
-          of damage into a single swing.
-        </em>
+        <em>{t("footnote1")}</em>
       </p>
       <p>
-        <em>
-          ** Probably a mistake to build a battle around monsters that dish out
-          damage like these do.
-        </em>
+        <em>{t("footnote2")}</em>
       </p>
     </>
   );

--- a/components/encounter-table.tsx
+++ b/components/encounter-table.tsx
@@ -1,6 +1,4 @@
-import { getI18nProperties } from "@/lib/get-static";
 import { toInteger } from "lodash";
-import { GetStaticPropsContext, GetStaticPropsResult } from "next";
 import { useTranslation } from "next-i18next";
 
 interface EncounterTableP {

--- a/lib/navigation.ts
+++ b/lib/navigation.ts
@@ -83,6 +83,7 @@ export function buildNav({
       },
       {
         labelKey: "nav.encounter-builder-label",
+        href: `/${locale}/calculator`,
       },
     ],
   };

--- a/pages/[locale]/calculator/index.tsx
+++ b/pages/[locale]/calculator/index.tsx
@@ -7,7 +7,7 @@ import {
   allRulesDocuments,
   allClassItems,
 } from "@/.contentlayer/generated";
-import { map, get, toInteger } from "lodash";
+import { map, get } from "lodash";
 import { GetStaticPropsContext, GetStaticPropsResult } from "next";
 import { getI18nProperties } from "@/lib/get-static";
 import VaultLayout from "@/layouts/vault";
@@ -118,7 +118,7 @@ export async function getStaticProps(
         classItems: allClassItems,
         ancestries: allAncestries,
       }),
-      ...(await getI18nProperties(context, ["home", "common"])),
+      ...(await getI18nProperties(context, ["common", "calculator"])),
     },
   };
 }

--- a/pages/[locale]/calculator/index.tsx
+++ b/pages/[locale]/calculator/index.tsx
@@ -11,6 +11,7 @@ import { map, get, toInteger } from "lodash";
 import { GetStaticPropsContext, GetStaticPropsResult } from "next";
 import { getI18nProperties } from "@/lib/get-static";
 import VaultLayout from "@/layouts/vault";
+import EncounterTable from "@/components/encounter-table";
 
 interface EncounterCalculatorP {
   navigation: Navigation;
@@ -21,26 +22,11 @@ export default function EncounterCalculator({
 }: EncounterCalculatorP) {
   const [state, setState] = useState(() => ({
     playerCount: 4,
+    battleCount: 4,
     level: 1,
-    battlecount: 4,
   }));
 
   // Calculate the values
-  const meqBudget = [0, 1, 2, 3, 5, 7, 9, 11][state.playerCount];
-  const mookFactor = [0, 3, 3, 4, 4, 5, 5, 5, 5, 5, 5][state.level];
-  let eliteMookFactor: number | string = mookFactor * 1.5;
-  if (eliteMookFactor !== toInteger(eliteMookFactor)) {
-    const low = Math.floor(eliteMookFactor);
-    const high = Math.ceil(eliteMookFactor);
-    eliteMookFactor = `${low}-${high}`;
-  }
-  const parLevelBase =
-    state.level < 5
-      ? state.level
-      : state.level < 8
-      ? state.level + 1
-      : state.level + 2;
-  const parLevel = state.battlecount === 4 ? parLevelBase : parLevelBase + 1;
 
   return (
     <>
@@ -85,17 +71,17 @@ export default function EncounterCalculator({
             />
 
             <p>
-              <label htmlFor="level">Battles/day: {state.battlecount}</label>
+              <label htmlFor="level">Battles/day: {state.battleCount}</label>
             </p>
             <input
               type="range"
               min="3"
               max="4"
-              value={state.battlecount}
+              value={state.battleCount}
               onChange={(ev) =>
                 setState((state) => ({
                   ...state,
-                  battlecount: parseInt(ev.target.value),
+                  battleCount: parseInt(ev.target.value),
                 }))
               }
             />
@@ -104,83 +90,11 @@ export default function EncounterCalculator({
       >
         <h1>Battle Budget Calculator</h1>
 
-        <p>
-          Budget for a standard battle: <strong>{meqBudget} MEQ</strong>
-        </p>
-
-        <div className="overflow-auto border dark:border-stone-700 rounded shadow bg-white dark:bg-stone-700 border-stone-300 my-2">
-          <table>
-            <thead>
-              <tr>
-                <th>Monster level</th>
-                <th>Standard / {mookFactor} mooks</th>
-                <th>Elite / {eliteMookFactor} mooks</th>
-                <th>2x / large / {mookFactor * 2} mooks</th>
-                <th>3x / huge / {mookFactor * 3} mooks</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td>{parLevel - 2}</td>
-                <td>0.5</td>
-                <td>0.7</td>
-                <td>1</td>
-                <td>1.5</td>
-              </tr>
-              <tr>
-                <td>{parLevel - 1}</td>
-                <td>0.7</td>
-                <td>1</td>
-                <td>1.5</td>
-                <td>2</td>
-              </tr>
-              <tr>
-                <td>
-                  <strong>{parLevel}</strong>
-                </td>
-                <td>
-                  <strong>1</strong>
-                </td>
-                <td>
-                  <strong>1.5</strong>
-                </td>
-                <td>
-                  <strong>2</strong>
-                </td>
-                <td>
-                  <strong>3</strong>
-                </td>
-              </tr>
-              <tr>
-                <td>{parLevel + 1}</td>
-                <td>1.5</td>
-                <td>2*</td>
-                <td>3*</td>
-                <td>4*</td>
-              </tr>
-              <tr>
-                <td>{parLevel + 2}</td>
-                <td>2*</td>
-                <td>3**</td>
-                <td>4**</td>
-                <td>6**</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-
-        <p>
-          <em>
-            * Be careful. A monster like this might pack an uncomfortable amount
-            of damage into a single swing.
-          </em>
-        </p>
-        <p>
-          <em>
-            ** Probably a mistake to build a battle around monsters that dish
-            out damage like these do.
-          </em>
-        </p>
+        <EncounterTable
+          playerCount={state.playerCount}
+          battleCount={state.battleCount}
+          level={state.level}
+        />
       </VaultLayout>
     </>
   );

--- a/pages/[locale]/calculator/index.tsx
+++ b/pages/[locale]/calculator/index.tsx
@@ -1,0 +1,57 @@
+import { supportedLocales } from "@/lib/locales";
+import { buildNav, Navigation } from "@/lib/navigation";
+import Head from "next/head";
+import BasicLayout from "@/layouts/basic";
+import {
+  allAncestries,
+  allRulesDocuments,
+  allClassItems,
+} from "@/.contentlayer/generated";
+import { map, get } from "lodash";
+import { GetStaticPropsContext, GetStaticPropsResult } from "next";
+import { getI18nProperties } from "@/lib/get-static";
+
+interface EncounterCalculatorP {
+  navigation: Navigation;
+}
+
+export default function EncounterCalculator({
+  navigation,
+}: EncounterCalculatorP) {
+  return (
+    <>
+      <Head>
+        <title>Encounter Calculator - 13 Vaults</title>
+      </Head>
+
+      <BasicLayout navigation={navigation}>
+        <div className="bg-stone-900 px-4 lg:px-8">
+          <h1>abc</h1>
+        </div>
+      </BasicLayout>
+    </>
+  );
+}
+
+export async function getStaticPaths() {
+  return {
+    paths: map(supportedLocales, (locale) => `/${locale}/calculator`),
+    fallback: false,
+  };
+}
+
+export async function getStaticProps(
+  context: GetStaticPropsContext
+): Promise<GetStaticPropsResult<EncounterCalculatorP>> {
+  return {
+    props: {
+      navigation: buildNav({
+        locale: String(get(context, "params.locale")),
+        rulesDocuments: allRulesDocuments,
+        classItems: allClassItems,
+        ancestries: allAncestries,
+      }),
+      ...(await getI18nProperties(context, ["home", "common"])),
+    },
+  };
+}

--- a/pages/[locale]/calculator/index.tsx
+++ b/pages/[locale]/calculator/index.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { supportedLocales } from "@/lib/locales";
 import { buildNav, Navigation } from "@/lib/navigation";
 import Head from "next/head";
@@ -18,6 +19,12 @@ interface EncounterCalculatorP {
 export default function EncounterCalculator({
   navigation,
 }: EncounterCalculatorP) {
+  const [state, setState] = useState(() => ({
+    playerCount: 4,
+    level: 1,
+    battlecount: 4,
+  }));
+
   return (
     <>
       <Head>
@@ -28,11 +35,57 @@ export default function EncounterCalculator({
         navigation={navigation}
         sideNavigation={
           <>
-            <h1>Nav yo</h1>
+            <p>
+              <label htmlFor="playercount">Players: {state.playerCount}</label>
+            </p>
+            <input
+              type="range"
+              min="1"
+              max="7"
+              value={state.playerCount}
+              onChange={(ev) =>
+                setState((state) => ({
+                  ...state,
+                  playerCount: parseInt(ev.target.value),
+                }))
+              }
+            />
+
+            <p>
+              <label htmlFor="level">Level: {state.level}</label>
+            </p>
+            <input
+              type="range"
+              min="1"
+              max="10"
+              value={state.level}
+              onChange={(ev) =>
+                setState((state) => ({
+                  ...state,
+                  level: parseInt(ev.target.value),
+                }))
+              }
+            />
+
+            <p>
+              <label htmlFor="level">Battles/day: {state.battlecount}</label>
+            </p>
+            <input
+              type="range"
+              min="3"
+              max="4"
+              value={state.battlecount}
+              onChange={(ev) =>
+                setState((state) => ({
+                  ...state,
+                  battlecount: parseInt(ev.target.value),
+                }))
+              }
+            />
           </>
         }
       >
-        <h1>abc</h1>
+        <h1>Player count: {state.playerCount}</h1>
       </VaultLayout>
     </>
   );

--- a/pages/[locale]/calculator/index.tsx
+++ b/pages/[locale]/calculator/index.tsx
@@ -1,7 +1,6 @@
 import { supportedLocales } from "@/lib/locales";
 import { buildNav, Navigation } from "@/lib/navigation";
 import Head from "next/head";
-import BasicLayout from "@/layouts/basic";
 import {
   allAncestries,
   allRulesDocuments,
@@ -10,6 +9,7 @@ import {
 import { map, get } from "lodash";
 import { GetStaticPropsContext, GetStaticPropsResult } from "next";
 import { getI18nProperties } from "@/lib/get-static";
+import VaultLayout from "@/layouts/vault";
 
 interface EncounterCalculatorP {
   navigation: Navigation;
@@ -24,11 +24,16 @@ export default function EncounterCalculator({
         <title>Encounter Calculator - 13 Vaults</title>
       </Head>
 
-      <BasicLayout navigation={navigation}>
-        <div className="bg-stone-900 px-4 lg:px-8">
-          <h1>abc</h1>
-        </div>
-      </BasicLayout>
+      <VaultLayout
+        navigation={navigation}
+        sideNavigation={
+          <>
+            <h1>Nav yo</h1>
+          </>
+        }
+      >
+        <h1>abc</h1>
+      </VaultLayout>
     </>
   );
 }

--- a/pages/[locale]/calculator/index.tsx
+++ b/pages/[locale]/calculator/index.tsx
@@ -46,10 +46,10 @@ export default function EncounterCalculator({
               min="1"
               max="7"
               value={state.playerCount}
-              onChange={(ev) =>
+              onChange={(event) =>
                 setState((state) => ({
                   ...state,
-                  playerCount: parseInt(ev.target.value),
+                  playerCount: Number.parseInt(event.target.value),
                 }))
               }
             />
@@ -62,10 +62,10 @@ export default function EncounterCalculator({
               min="1"
               max="10"
               value={state.level}
-              onChange={(ev) =>
+              onChange={(event) =>
                 setState((state) => ({
                   ...state,
-                  level: parseInt(ev.target.value),
+                  level: Number.parseInt(event.target.value),
                 }))
               }
             />
@@ -78,10 +78,10 @@ export default function EncounterCalculator({
               min="3"
               max="4"
               value={state.battleCount}
-              onChange={(ev) =>
+              onChange={(event) =>
                 setState((state) => ({
                   ...state,
-                  battleCount: parseInt(ev.target.value),
+                  battleCount: Number.parseInt(event.target.value),
                 }))
               }
             />

--- a/pages/[locale]/calculator/index.tsx
+++ b/pages/[locale]/calculator/index.tsx
@@ -7,7 +7,7 @@ import {
   allRulesDocuments,
   allClassItems,
 } from "@/.contentlayer/generated";
-import { map, get } from "lodash";
+import { map, get, toInteger } from "lodash";
 import { GetStaticPropsContext, GetStaticPropsResult } from "next";
 import { getI18nProperties } from "@/lib/get-static";
 import VaultLayout from "@/layouts/vault";
@@ -24,6 +24,23 @@ export default function EncounterCalculator({
     level: 1,
     battlecount: 4,
   }));
+
+  // Calculate the values
+  const meqBudget = [0, 1, 2, 3, 5, 7, 9, 11][state.playerCount];
+  const mookFactor = [0, 3, 3, 4, 4, 5, 5, 5, 5, 5, 5][state.level];
+  let eliteMookFactor: number | string = mookFactor * 1.5;
+  if (eliteMookFactor !== toInteger(eliteMookFactor)) {
+    const low = Math.floor(eliteMookFactor);
+    const high = Math.ceil(eliteMookFactor);
+    eliteMookFactor = `${low}-${high}`;
+  }
+  const parLevelBase =
+    state.level < 5
+      ? state.level
+      : state.level < 8
+      ? state.level + 1
+      : state.level + 2;
+  const parLevel = state.battlecount === 4 ? parLevelBase : parLevelBase + 1;
 
   return (
     <>
@@ -85,7 +102,85 @@ export default function EncounterCalculator({
           </>
         }
       >
-        <h1>Player count: {state.playerCount}</h1>
+        <h1>Battle Budget Calculator</h1>
+
+        <p>
+          Budget for a standard battle: <strong>{meqBudget} MEQ</strong>
+        </p>
+
+        <div className="overflow-auto border dark:border-stone-700 rounded shadow bg-white dark:bg-stone-700 border-stone-300 my-2">
+          <table>
+            <thead>
+              <tr>
+                <th>Monster level</th>
+                <th>Standard / {mookFactor} mooks</th>
+                <th>Elite / {eliteMookFactor} mooks</th>
+                <th>2x / large / {mookFactor * 2} mooks</th>
+                <th>3x / huge / {mookFactor * 3} mooks</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>{parLevel - 2}</td>
+                <td>0.5</td>
+                <td>0.7</td>
+                <td>1</td>
+                <td>1.5</td>
+              </tr>
+              <tr>
+                <td>{parLevel - 1}</td>
+                <td>0.7</td>
+                <td>1</td>
+                <td>1.5</td>
+                <td>2</td>
+              </tr>
+              <tr>
+                <td>
+                  <strong>{parLevel}</strong>
+                </td>
+                <td>
+                  <strong>1</strong>
+                </td>
+                <td>
+                  <strong>1.5</strong>
+                </td>
+                <td>
+                  <strong>2</strong>
+                </td>
+                <td>
+                  <strong>3</strong>
+                </td>
+              </tr>
+              <tr>
+                <td>{parLevel + 1}</td>
+                <td>1.5</td>
+                <td>2*</td>
+                <td>3*</td>
+                <td>4*</td>
+              </tr>
+              <tr>
+                <td>{parLevel + 2}</td>
+                <td>2*</td>
+                <td>3**</td>
+                <td>4**</td>
+                <td>6**</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <p>
+          <em>
+            * Be careful. A monster like this might pack an uncomfortable amount
+            of damage into a single swing.
+          </em>
+        </p>
+        <p>
+          <em>
+            ** Probably a mistake to build a battle around monsters that dish
+            out damage like these do.
+          </em>
+        </p>
       </VaultLayout>
     </>
   );

--- a/public/locales/en/calculator.json
+++ b/public/locales/en/calculator.json
@@ -1,0 +1,11 @@
+{
+  "budget": "Budget for a standard battle:",
+  "budgetresult": "{{meq}} MEQ",
+  "monsterlevel": "Monster level",
+  "standard": "Standard / {{mooks}} mooks",
+  "elite": "Elite / {{mooks}} mooks",
+  "large": "2x / large / {{mooks}} mooks",
+  "huge": "3x / huge / {{mooks}} mooks",
+  "footnote1": "* Be careful. A monster like this might pack an uncomfortable amount of damage into a single swing.",
+  "footnote2": "** Probably a mistake to build a battle around monsters that dish out damage like these do."
+}


### PR DESCRIPTION
This adds a basic encounter-budget calculator like the one at https://ben.github.io/13acalc/ as a placeholder until the full encounter builder can be added.

- [x] Add a page
- [x] Implement controls and table